### PR TITLE
Add mobile-friendly floating action buttons to warehouse

### DIFF
--- a/client/pages/Warehouse.tsx
+++ b/client/pages/Warehouse.tsx
@@ -3490,13 +3490,29 @@ export default function Warehouse() {
 
       <div className="fixed bottom-24 right-4 z-40 sm:hidden">
         <div className="flex gap-2">
-          <Button className="shadow-business-lg" size="icon" aria-label="Stock In" onClick={() => openStockDialog("in")}>
+          <Button
+            className="shadow-business-lg"
+            size="icon"
+            aria-label="Stock In"
+            onClick={() => openStockDialog("in")}
+          >
             <ArrowUp className="h-5 w-5" />
           </Button>
-          <Button variant="destructive" className="shadow-business-lg" size="icon" aria-label="Stock Out" onClick={() => openStockDialog("out")}>
+          <Button
+            variant="destructive"
+            className="shadow-business-lg"
+            size="icon"
+            aria-label="Stock Out"
+            onClick={() => openStockDialog("out")}
+          >
             <ArrowDown className="h-5 w-5" />
           </Button>
-          <Button className="shadow-business-lg" size="icon" aria-label="Add Product" onClick={() => setIsAddDialogOpen(true)}>
+          <Button
+            className="shadow-business-lg"
+            size="icon"
+            aria-label="Add Product"
+            onClick={() => setIsAddDialogOpen(true)}
+          >
             <Plus className="h-5 w-5" />
           </Button>
         </div>

--- a/client/pages/Warehouse.tsx
+++ b/client/pages/Warehouse.tsx
@@ -2334,7 +2334,7 @@ export default function Warehouse() {
         </div>
 
         {/* Action Buttons */}
-        <div className="flex items-center gap-3">
+        <div className="hidden sm:flex items-center gap-3">
           <Button
             variant="outline"
             className="bg-green-50 hover:bg-green-100 text-green-700 border-green-200"
@@ -3487,6 +3487,20 @@ export default function Warehouse() {
           </Card>
         </TabsContent>
       </Tabs>
+
+      <div className="fixed bottom-24 right-4 z-40 sm:hidden">
+        <div className="flex gap-2">
+          <Button className="shadow-business-lg" size="icon" aria-label="Stock In" onClick={() => openStockDialog("in")}>
+            <ArrowUp className="h-5 w-5" />
+          </Button>
+          <Button variant="destructive" className="shadow-business-lg" size="icon" aria-label="Stock Out" onClick={() => openStockDialog("out")}>
+            <ArrowDown className="h-5 w-5" />
+          </Button>
+          <Button className="shadow-business-lg" size="icon" aria-label="Add Product" onClick={() => setIsAddDialogOpen(true)}>
+            <Plus className="h-5 w-5" />
+          </Button>
+        </div>
+      </div>
 
       {/* Edit Product Dialog */}
       <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>


### PR DESCRIPTION
## Purpose

The user requested a mobile-optimized version of the warehouse management interface that is easy to use and comfortable on mobile devices. This change improves mobile usability by providing accessible action buttons for core warehouse operations.

## Code changes

- **Hide desktop action buttons on mobile**: Added `hidden sm:flex` classes to existing action button container to hide it on small screens
- **Add floating action buttons for mobile**: Created a new fixed-position button group in the bottom-right corner that only appears on mobile (`sm:hidden`)
- **Mobile button functionality**: Added three floating action buttons with proper icons and accessibility labels:
  - Stock In button (ArrowUp icon) - triggers stock in dialog
  - Stock Out button (ArrowDown icon) - triggers stock out dialog  
  - Add Product button (Plus icon) - opens add product dialog
- **Enhanced mobile UX**: Positioned buttons at `bottom-24 right-4` with shadow styling for better visibility and touch accessibility

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8df0fba0609c432583512ec5726c35fd/vortex-field)

👀 [Preview Link](https://8df0fba0609c432583512ec5726c35fd-vortex-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8df0fba0609c432583512ec5726c35fd</projectId>-->
<!--<branchName>vortex-field</branchName>-->